### PR TITLE
Create Easy Chili Garlic Oil Noodles

### DIFF
--- a/Easy Chili Garlic Oil Noodles
+++ b/Easy Chili Garlic Oil Noodles
@@ -1,0 +1,15 @@
+INGREDIENTS
+4 oz thick wheat noodles taiwanese sliced noodles, udon, or ramen noodles
+3 tbsp neutral oil
+3 cloves garlic minced
+1 tbsp sichuan chili flakes or korean or regular chili flakes to taste
+1 green onion chopped, divided
+1/2 tbsp light soy sauce
+1/2 tsp dark soy sauce
+1/2 tsp chinese black vinegar or rice vinegar, to taste
+1/4 tsp each sugar, salt or chicken bouillon powder (see notes below)
+cilantro, green onion, and/or toasted sesame seeds for garnish, optional
+INSTRUCTIONS
+Cook noodles according to package instructions. Drain and place in a bowl. To serve the noodles cold, rinse under cold water for a few seconds then drain.
+Add garlic, chili flakes, white parts of green onion, light & dark soy sauce, chinese black vinegar, salt, and sugar over the noodles.
+Heat oil in a saucepan until sizzling hot. Pour the hot oil over the chili flakes and garlic, and mix until the noodles are evenly coated. Garnish, add more soy sauce if needed, and enjoy!


### PR DESCRIPTION
INGREDIENTS
4 oz [thick wheat noodles](https://amzn.to/3QuGzx1) taiwanese sliced noodles, udon, or ramen noodles
3 tbsp neutral oil
3 cloves garlic minced
1 tbsp [sichuan chili flakes](https://amzn.to/3ynK3eg) or korean or regular chili flakes to taste
1 green onion chopped, divided
1/2 tbsp [light soy sauce](https://amzn.to/3ykK5nd)
1/2 tsp [dark soy sauce](https://amzn.to/3OWFNsK)
1/2 tsp [chinese black vinegar](https://amzn.to/3K5Y0BC) or rice vinegar, to taste
1/4 tsp each sugar, salt or chicken bouillon powder (see notes below)
cilantro, green onion, and/or toasted sesame seeds for garnish, optional
INSTRUCTIONS
Cook noodles according to package instructions. Drain and place in a bowl. To serve the noodles cold, rinse under cold water for a few seconds then drain.
Add garlic, chili flakes, white parts of green onion, light & dark soy sauce, chinese black vinegar, salt, and sugar over the noodles.
Heat oil in a saucepan until sizzling hot. Pour the hot oil over the chili flakes and garlic, and mix until the noodles are evenly coated. Garnish, add more soy sauce if needed, and enjoy!